### PR TITLE
Fixes for running gitolite as an alternate unix user 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ If you want to supply your own config/keys to the `gitolite-admin.git` repositor
 By default, gitolite is installed to '/var/lib/gitolite', with a user & group of 'gitolite'. This is configurable:
 
     class { 'gitolite':
-      base     = "/etc/gitolite"
-      user     = "git"
-      group    = "git"
+      base     => "/etc/gitolite",
+      user     => "git",
+      group    => "git",
     }
 
 # Adding more repositories

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,16 +4,16 @@ class gitolite::config {
   file { "$gitolite::base/.gitolite.rc":
     ensure  => present,
     mode    => 0660,
-    owner   => "gitolite",
-    group   => "gitolite",
+    owner   => "$gitolite::user",
+    group   => "$gitolite::group",
     source  => "puppet:///modules/gitolite/gitolite-rc",
   }
 
   file { "$gitolite::base/admin-update.sh":
     ensure => present,
     mode    => 0770,
-    owner   => "gitolite",
-    group   => "gitolite",
+    owner   => "$gitolite::user",
+    group   => "$gitolite::group",
     content => template('gitolite/admin-update.sh.erb'),
   }
 


### PR DESCRIPTION
- Replace hardcoded references to "gitolite" user and group with
  "$gitolite::user" and "$gitolite::group", respectively.
- Fix documentation: correct syntax in example of alternate unix
  user/path for gitolite.
